### PR TITLE
is_ascii() returns NA for NA_character_

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: xfun
 Type: Package
 Title: Miscellaneous Functions by 'Yihui Xie'
-Version: 0.3.7
+Version: 0.3.8
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre", "cph"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person("Daijiang", "Li", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 - The argument `rw_error` was moved from `gsub_dir()` to `gsub_file()` (`gsub_dir(rw_error = ...)` will still work).
 
+- `is_ascii()` now returns `NA` for `NA_character_` (thanks, @shrektan, #8 #9).
+
 # CHANGES IN xfun VERSION 0.3
 
 ## NEW FEATURES

--- a/R/encoding.R
+++ b/R/encoding.R
@@ -33,4 +33,8 @@ native_encode = function(x, windows_only = is_windows()) {
 #' @examples library(xfun)
 #' is_ascii(letters)  # yes
 #' is_ascii(intToUtf8(8212))  # no
-is_ascii = function(x) !is.na(iconv(x, to = 'ascii'))
+is_ascii = function(x) {
+  out <- !is.na(iconv(x, to = 'ascii'))
+  out[is.na(x)] <- NA
+  out
+}

--- a/R/encoding.R
+++ b/R/encoding.R
@@ -34,7 +34,7 @@ native_encode = function(x, windows_only = is_windows()) {
 #' is_ascii(letters)  # yes
 #' is_ascii(intToUtf8(8212))  # no
 is_ascii = function(x) {
-  out <- !is.na(iconv(x, to = 'ascii'))
-  out[is.na(x)] <- NA
+  out = !is.na(iconv(x, to = 'ascii'))
+  out[is.na(x)] = NA
   out
 }


### PR DESCRIPTION
Closes #8 Now :

```r
is_ascii(c("辅导费", "aaa", 1, "", NA_character_))
# [1] FALSE  TRUE  TRUE  TRUE    NA
```

I actually searched `is_ascii()` in the repos of the reverse depended packages and didn't find it being used. So it won't break the existing code and thus can be safely merged.