### PR TITLE
add tests for json.R

### DIFF
--- a/tests/testit/test-json.R
+++ b/tests/testit/test-json.R
@@ -1,0 +1,25 @@
+library(testit)
+
+assert("tojson works", {
+  (tojson(NULL) %==% "null")
+  (tojson(list()) %==% "{}")
+  (has_error(tojson(Sys.Date())))
+  (has_error(tojson(NA)))
+  (tojson(NA_character_) %==% '"NA"')
+  (tojson(1:10) %==% "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]")
+  (tojson(TRUE) %==% "true")
+  (tojson(FALSE) %==% "false")
+
+  x <- list(a = 1, b = list(c = 1:3, d = "abc"))
+  out <- '{\n"a": 1,\n"b": {\n"c": [1, 2, 3],\n"d": "abc"\n}\n}'
+  (tojson(x) %==% out)
+
+  x <- list(c("a", "b"), 1:5, TRUE)
+  out <- '[["a", "b"], [1, 2, 3, 4, 5], true]'
+  (tojson(x) %==% out)
+
+  JS = function(x) structure(x, class = "JS_EVAL")
+  x <- list(a = 1:5, b = JS("function() {return true;}"))
+  out <- '{\n"a": [1, 2, 3, 4, 5],\n"b": function() {return true;}\n}'
+  (tojson(x) %==% out)
+})

--- a/tests/testit/test-json.R
+++ b/tests/testit/test-json.R
@@ -1,6 +1,6 @@
 library(testit)
 
-assert("tojson works", {
+assert("tojson() works", {
   (tojson(NULL) %==% "null")
   (tojson(list()) %==% "{}")
   (has_error(tojson(Sys.Date())))
@@ -10,16 +10,16 @@ assert("tojson works", {
   (tojson(TRUE) %==% "true")
   (tojson(FALSE) %==% "false")
 
-  x <- list(a = 1, b = list(c = 1:3, d = "abc"))
-  out <- '{\n"a": 1,\n"b": {\n"c": [1, 2, 3],\n"d": "abc"\n}\n}'
+  x = list(a = 1, b = list(c = 1:3, d = "abc"))
+  out = '{\n"a": 1,\n"b": {\n"c": [1, 2, 3],\n"d": "abc"\n}\n}'
   (tojson(x) %==% out)
 
-  x <- list(c("a", "b"), 1:5, TRUE)
-  out <- '[["a", "b"], [1, 2, 3, 4, 5], true]'
+  x = list(c("a", "b"), 1:5, TRUE)
+  out = '[["a", "b"], [1, 2, 3, 4, 5], true]'
   (tojson(x) %==% out)
 
   JS = function(x) structure(x, class = "JS_EVAL")
-  x <- list(a = 1:5, b = JS("function() {return true;}"))
-  out <- '{\n"a": [1, 2, 3, 4, 5],\n"b": function() {return true;}\n}'
+  x = list(a = 1:5, b = JS("function() {return true;}"))
+  out = '{\n"a": [1, 2, 3, 4, 5],\n"b": function() {return true;}\n}'
   (tojson(x) %==% out)
 })


### PR DESCRIPTION
Actually, the NA handling looks inconsistent...

``` r
library(xfun)
#> 
#> Attaching package: 'xfun'
#> The following objects are masked from 'package:base':
#> 
#>     attr, isFALSE
tojson(NA_character_)
#> [1] "\"NA\""
tojson(NA_integer_)
#> [1] NA
tojson(NA_real_)
#> [1] NA
tojson(NaN)
#> [1] NaN
```

<sup>Created on 2018-11-27 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>