### PR TITLE
add tests for loadable()

### DIFF
--- a/R/packages.R
+++ b/R/packages.R
@@ -69,6 +69,7 @@ pkg_load = function(..., error = TRUE, install = FALSE) {
 #' @rdname pkg_attach
 #' @export
 loadable = function(pkg, strict = TRUE, new_session = FALSE) {
+  if (length(pkg) != 1L) stop("'pkg' must be a length one character")
   if (new_session) {
     Rscript(c('-e', shQuote(sprintf('library("%s")', pkg))), stdout = FALSE, stderr = FALSE) == 0
   } else {

--- a/tests/testit/test-packages.R
+++ b/tests/testit/test-packages.R
@@ -1,0 +1,12 @@
+library(testit)
+
+assert("loadable works", {
+  (loadable("base") %==% TRUE)
+  (loadable("base", new_session = TRUE) %==% TRUE)
+  (loadable("base", strict = FALSE) %==% TRUE)
+  (has_error(loadable(c("base", "base2"))))
+  (has_error(loadable(character())))
+  (loadable("#base") %==% FALSE)
+  (loadable("#base", new_session = TRUE) %==% FALSE)
+  (loadable("#base", strict = FALSE) %==% FALSE)
+})


### PR DESCRIPTION

If don't check the length, the `loadable()` may surprise users... 

``` r
library(xfun)
#> 
#> Attaching package: 'xfun'
#> The following objects are masked from 'package:base':
#> 
#>     attr, isFALSE
loadable(c("base", "#abc"), new_session = TRUE)
#> [1] TRUE
```

<sup>Created on 2018-11-27 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>