### PR TITLE
fix the bug that prose_index() recongizes double back-ticks as code fences

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Version: 0.4.4
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre", "cph"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person("Daijiang", "Li", role = "ctb"),
-  person("Xianying", "Tan", role = "ctb")
+  person("Xianying", "Tan", role = "ctb"),
+  person()
   )
 Description: Miscellaneous functions commonly used in other packages maintained by 'Yihui Xie'.
 Imports: tools

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: xfun
 Type: Package
 Title: Miscellaneous Functions by 'Yihui Xie'
-Version: 0.4.3
+Version: 0.4.4
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre", "cph"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person("Daijiang", "Li", role = "ctb"),
-  person()
+  person("Xianying", "Tan", role = "ctb")
   )
 Description: Miscellaneous functions commonly used in other packages maintained by 'Yihui Xie'.
 Imports: tools

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## BUG FIXES
 
-- Fixed the bug that `prose_index()` reconginizes double back-ticks as code fences (thanks, @shrektan, #14 #15).
+- Fixed the bug that `prose_index()` recognizes double backticks as code fences (thanks, @shrektan, #14 #15).
 
 # CHANGES IN xfun VERSION 0.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # CHANGES IN xfun VERSION 0.5
 
+## BUG FIXES
 
+- Fixed the bug that `prose_index()` reconginizes double back-ticks as code fences (thanks, @shrektan, #14 #15).
 
 # CHANGES IN xfun VERSION 0.4
 

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -11,7 +11,7 @@
 #' prose_index(c('a', '```', 'b', '```', 'c'))
 #' prose_index(c('a', '````', '```r', '1+1', '```', '````', 'c'))
 prose_index = function(x) {
-  idx = NULL; r = '^(\\s*```*).*'; s = ''
+  idx = NULL; r = '^(\\s*```+).*'; s = ''
   for (i in grep(r, x)) {
     if (s == '') {
       s = gsub(r, '\\1', x[i]); idx = c(idx, i); next

--- a/tests/testit/test-markdown.R
+++ b/tests/testit/test-markdown.R
@@ -1,0 +1,46 @@
+library(testit)
+
+assert('prose_index() works', {
+  x = c('a', '```', 'b', '```', 'c')
+  out = c(1L, 5L)
+  (prose_index(x) %==% out)
+
+  x = c('a', '````', '```r', '1+1', '```', '````', 'c')
+  out = c(1L, 7L)
+  (prose_index(x) %==% out)
+
+  x = c('a', '``', 'b', '``', 'c')
+  out = seq_along(x)
+  (prose_index(x) %==% out)
+
+  # a character vector of length zero
+  x = character()
+  out = integer()
+  (prose_index(x) %==% out)
+
+  # one backbrick
+  x = c('`', 'a', '`')
+  out = seq_along(x)
+  (prose_index(x) %==% out)
+
+  # two backbrick
+  x = c('``', 'a', '``')
+  out = seq_along(x)
+  (prose_index(x) %==% out)
+
+  # no code fences
+  x = c('a', 'b')
+  out = c(1L, 2L)
+  (prose_index(x) %==% out)
+
+  # two code fences
+  x = c('```', 'b', '```', '```', 'd', '```')
+  out = integer()
+  (prose_index(x) %==% out)
+
+  # if the code fences are not balanced
+  x = c('a', '```', 'b', '``', 'c')
+  out = seq_along(x)
+  (has_warning(prose_index(x)))
+  (prose_index(x) %==% out)
+})


### PR DESCRIPTION
Closes #14 

Add tests for `prose_index()` as well.