### PR TITLE
change domain for website yihui.name to yihui.org

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,7 @@ Please keep the below portion in your issue. Your issue will be closed if any of
 
 By filing an issue to this repo, I promise that
 
-- [ ] I have fully read the issue guide at https://yihui.name/issue/.
+- [ ] I have fully read the issue guide at https://yihui.org/issue/.
 - [ ] I have provided the necessary information about my issue.
     - If I'm asking a question, I have already asked it on Stack Overflow or RStudio Community, waited for at least 24 hours, and included a link to my question there.
     - If I'm filing a bug report, I have included a minimal, self-contained, and reproducible example, and have also included `xfun::session_info('xfun')`. I have upgraded all my packages to their latest versions (e.g., R, RStudio, and R packages), and also tried the development version: `remotes::install_github('yihui/xfun')`.

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ repos:
   XRAN: https://xran.yihui.org
 
 before_install:
-  - "curl https://xran.yihui.org/.gitconfig -o ~/.gitconfig"
+  - "curl -L https://xran.yihui.org/.gitconfig -o ~/.gitconfig"
 
 after_success:
   - Rscript -e 'if (!require("covr")) install.packages("covr"); covr::codecov()'
-  - "(curl https://xran.yihui.org/r-xran | bash)"
+  - "(curl -L https://xran.yihui.org/r-xran | bash)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ env:
     - R_PKG="$(basename $TRAVIS_REPO_SLUG)" _R_CHECK_TESTS_NLINES_=0
 
 repos:
-  XRAN: https://xran.yihui.name
+  XRAN: https://xran.yihui.org
 
 before_install:
-  - "curl https://xran.yihui.name/.gitconfig -o ~/.gitconfig"
+  - "curl https://xran.yihui.org/.gitconfig -o ~/.gitconfig"
 
 after_success:
   - Rscript -e 'if (!require("covr")) install.packages("covr"); covr::codecov()'
-  - "(curl https://xran.yihui.name/r-xran | bash)"
+  - "(curl https://xran.yihui.org/r-xran | bash)"


### PR DESCRIPTION
This changes the domain of the website in `travis.yml` where redirection are not handled by curl currently

should we change also anywhere in the source code ? Do you want to handle only with redirection ?
I am thinking it could be better to replace all 

You seem to have already change in documentation in 7dd847fc9e23f2a1a5d38f568d248aee80d20548