### PR TITLE
crandalf improvment to trigger build

### DIFF
--- a/R/revcheck.R
+++ b/R/revcheck.R
@@ -434,8 +434,8 @@ crandalf_check = function(pkg, size = 400, jobs = Inf, which = 'all') {
     message('No need to split ', n, ' reverse dependencies into batches of size ', size, '.')
     if (any(grepl('Your branch is ahead of ', git('status', stdout = TRUE)))) {
       git('push')
-    } else if (Sys.which('gh') != '' && !is.null(id <- crandalf_id(pkg))) {
-      gh(c('run', 'rerun', id))
+    } else if (Sys.which('gh') != '') {
+      gh(c('workflow', 'run', 'rev-check.yaml'; '--ref', b))
     } else {
       message('Remember to re-run the last job for the package ', pkg, ' on Github.')
     }

--- a/R/revcheck.R
+++ b/R/revcheck.R
@@ -435,7 +435,7 @@ crandalf_check = function(pkg, size = 400, jobs = Inf, which = 'all') {
     if (any(grepl('Your branch is ahead of ', git('status', stdout = TRUE)))) {
       git('push')
     } else if (Sys.which('gh') != '') {
-      gh(c('workflow', 'run', 'rev-check.yaml'; '--ref', b))
+      gh(c('workflow', 'run', 'rev-check.yaml', '--ref', b))
     } else {
       message('Remember to re-run the last job for the package ', pkg, ' on Github.')
     }

--- a/R/revcheck.R
+++ b/R/revcheck.R
@@ -436,6 +436,7 @@ crandalf_check = function(pkg, size = 400, jobs = Inf, which = 'all') {
       git('push')
     } else if (Sys.which('gh') != '') {
       gh(c('workflow', 'run', 'rev-check.yaml', '--ref', b))
+      message('Triggering rev-check.yaml job against ', b, ' branch in crandalf repo on Github.')
     } else {
       message('Remember to re-run the last job for the package ', pkg, ' on Github.')
     }


### PR DESCRIPTION
This PR now use `gh workflow run rev-check.yaml --ref <branch>` to manually trigger a workflow in the branch. 

This will always work even for old PR with deleted runs, which was not the case before. 

`crandalf_id()` does not seems useful anymore but I did not remove it.

I got other config issues on Windows and various things, but nothing really that should be improved in **xfun** directly I think. I'll PR other things if needed. 

This closes https://github.com/yihui/crandalf/issues/23