### PR TITLE
use file.path instead of paste0 in cache_rds

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -112,7 +112,7 @@ cache_rds = function(
     if (missing(dir) && !is.null(d <- knitr::opts_current$get('cache.path')))
       dir = d
   }
-  path = paste0(dir, file)
+  path = file.path(dir, file)
   if (!grepl(r <- '([.]rds)$', path)) path = paste0(path, '.rds')
   code = deparse(substitute(expr))
   md5  = md5sum_obj(code)


### PR DESCRIPTION
Very simple change, so that is not necessary to pass a trailing slash (`/`) to the `dir` argument of `cache_rds`. This is specially useful when the using `file.path()` itself for the `dir` argument, such as: 

```r
path <- list(checkpoints = file.path("checkpoints"))

long_calcs <- cache_rds(
  expr = {
    Sys.sleep(10)
  },
  dir = file.path(path$checkpoints)
)
```

Maybe it is a better practice to always use a trailing slash for folders and no slash for files, but it is not always practical. The output of `here::here()`, for example, doesn't differ between folder and files in this way. 

Please let me know if I am doing something wrong, or just disregard the PR. Thank you for these great miscellaneous functions :)