### PR TITLE
remove the C++ standard specification

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,1 +1,0 @@
-CXX_STD = CXX11


### PR DESCRIPTION
https://github.com/wch/r-source/commit/eb2531413e22a939e051be97ed062f29306b12e9

https://cran.r-project.org/web/checks/check_results_xfun.html

```
checking C++ specification ... NOTE
  Specified C++11: please update to current default of C++17
```