### PR TITLE
Fix for `is_arm64()` function to support Linux

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CHANGES IN xfun VERSION 0.38
 
+- `is_arm64()` also supports Linux now (thanks, @eitsupi, #74).
 
 # CHANGES IN xfun VERSION 0.37
 

--- a/R/os.R
+++ b/R/os.R
@@ -28,4 +28,4 @@ is_linux = function() unname(Sys.info()['sysname'] == 'Linux')
 
 #' @rdname os
 #' @export
-is_arm64 = function() Sys.info()[['machine']] == 'arm64'
+is_arm64 = function() Sys.info()[['machine']] %in% c('arm64', 'aarch64')


### PR DESCRIPTION
I recommend supporting Linux as well, because when we simply write arm64, it is not limited to macOS.

I tested R on Docker on Raspberry Pi 4.

```sh
$ docker run --rm -it r-base R -s -e 'Sys.info()[["machine"]]'
[1] "aarch64"
$ uname -m
aarch64
$ dpkg --print-architecture
arm64
```