### PR TITLE
解决 `session_info()` 无法正确识别 Positron 问题

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - `md_table()` should add a vertical ellipsis to row names when rows are truncated by the `limit` argument.
 
+- `session_info()` recognizes Positron now (thanks, @chuxinyuan, #89).
+
 # CHANGES IN xfun VERSION 0.45
 
 - For `record()` with `verbose = 1` or `2`, invisible `NULL` is no longer printed.

--- a/R/session.R
+++ b/R/session.R
@@ -35,7 +35,7 @@ session_info = function(packages = NULL, dependencies = TRUE) {
   } else if (Sys.getenv("RSTUDIO") == "1") {
     res$running = paste0(res$running, ', RStudio ', rstudioapi::getVersion())
   } else {
-    res$running = paste0(res$running, ', Rgui')
+    res$running = paste0(res$running, ', ', .Platform$GUI)
   }
 
   tweak_info = function(obj, extra = NULL) {

--- a/R/session.R
+++ b/R/session.R
@@ -30,8 +30,12 @@
 session_info = function(packages = NULL, dependencies = TRUE) {
   res = sessionInfo()
   res$matprod = res$BLAS = res$LAPACK = NULL
-  if (loadable('rstudioapi') && rstudioapi::isAvailable()) {
+  if (Sys.getenv("POSITRON") == "1") {
+    res$running = paste0(res$running, ', Positron ', Sys.getenv("POSITRON_VERSION"))
+  } else if (Sys.getenv("RSTUDIO") == "1") {
     res$running = paste0(res$running, ', RStudio ', rstudioapi::getVersion())
+  } else {
+    res$running = paste0(res$running, ', Rgui')
   }
 
   tweak_info = function(obj, extra = NULL) {

--- a/R/session.R
+++ b/R/session.R
@@ -30,13 +30,11 @@
 session_info = function(packages = NULL, dependencies = TRUE) {
   res = sessionInfo()
   res$matprod = res$BLAS = res$LAPACK = NULL
-  if (Sys.getenv("POSITRON") == "1") {
-    res$running = paste0(res$running, ', Positron ', Sys.getenv("POSITRON_VERSION"))
-  } else if (Sys.getenv("RSTUDIO") == "1") {
-    res$running = paste0(res$running, ', RStudio ', rstudioapi::getVersion())
-  } else {
-    res$running = paste0(res$running, ', ', .Platform$GUI)
-  }
+  res$running = paste(c(res$running, if (Sys.getenv('POSITRON') == '1') {
+    c(', Positron ', Sys.getenv('POSITRON_VERSION'))
+  } else if (Sys.getenv('RSTUDIO') == '1') {
+    c(', RStudio ', rstudioapi::getVersion())
+  }), collapse = '')
 
   tweak_info = function(obj, extra = NULL) {
     res = capture.output(print(obj, tzone = FALSE))


### PR DESCRIPTION
解决 <https://github.com/yihui/xfun/issues/88> 提到的无法识别 Positron 的问题。