### PR TITLE
Fix for various types of indent styles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 - `md_table()` escapes `|` in the table to `\|` instead of `&#124;` now.
 
+- `yaml_load(use_yaml = FALSE)` allows for indenting sub-fields by any number of spaces now (thanks, @J-Moravec, #95). Previously, one level of indentation must use exactly 2 spaces.
+
 - `divide_chunk()` no longer requires every line of chunk options to be commented out when the engine uses a pair of comment delimiters (such as `/*` and `*/` for CSS) instead of a single comment character. It suffices to use the opening delimiter at the beginning and closing delimiter at the end, e.g.,
 
   ````md

--- a/R/yaml.R
+++ b/R/yaml.R
@@ -49,7 +49,7 @@ yaml_load = function(
   ))
   # the below simple parser is quite limited
   res = list()
-  r = '^(\\s*)([^ ]+?):($|\\s+.*)'
+  r = '^(\\s*)(.+?):($|\\s+.*)'
   x = split_lines(x)
   x = x[grep(r, x)]
   x = x[grep('^\\s*#', x, invert = TRUE)]  # comments
@@ -72,12 +72,10 @@ yaml_load = function(
   res
 }
 
-
 indent_level = function(x) {
   N = nchar(x); n = N[N > 0]
   if (length(n) == 0) N else ceiling(N / min(n))
 }
-
 
 # only support logical, numeric, character values (both scalar and [] arrays),
 # and R expressions starting with !r/!expr

--- a/R/yaml.R
+++ b/R/yaml.R
@@ -49,7 +49,7 @@ yaml_load = function(
   ))
   # the below simple parser is quite limited
   res = list()
-  r = '^(\\s*)([^\\s]+?):($|\\s+.*)'
+  r = '^(\\s*)([^[:blank:]]+?):($|\\s+.*)'
   x = split_lines(x)
   x = x[grep(r, x)]
   x = x[grep('^\\s*#', x, invert = TRUE)]  # comments

--- a/R/yaml.R
+++ b/R/yaml.R
@@ -49,14 +49,13 @@ yaml_load = function(
   ))
   # the below simple parser is quite limited
   res = list()
-  r = '^(\\s*)([^[:blank:]]+?):($|\\s+.*)'
+  r = '^(\\s*)([^ ]+?):($|\\s+.*)'
   x = split_lines(x)
   x = x[grep(r, x)]
   x = x[grep('^\\s*#', x, invert = TRUE)]  # comments
   if (length(x) == 0) return(res)
   lvl = gsub(r, '\\1', x)  # indentation level
-  lvl = gsub('\t', ' ', lvl) # turn tabs into spaces
-  lvl = guess_indent_length(lvl)
+  lvl = indent_level(lvl)
   key = gsub(r, '\\2', x)
   val = gsub('^\\s*|\\s*$', '', gsub(r, '\\3', x))
   keys = NULL
@@ -74,13 +73,11 @@ yaml_load = function(
 }
 
 
-guess_indent_length = function(x) {
-  x = nchar(x)
-  y = min(setdiff(x, 0))
-  if(!all((x %% y) == 0))
-    stop('Irregular indentation in YAML header')
-  x / y
+indent_level = function(x) {
+  N = nchar(x); n = N[N > 0]
+  if (length(n) == 0) N else ceiling(N / min(n))
 }
+
 
 # only support logical, numeric, character values (both scalar and [] arrays),
 # and R expressions starting with !r/!expr

--- a/tests/test-cran/test-yaml.R
+++ b/tests/test-cran/test-yaml.R
@@ -9,6 +9,25 @@ d:
   f: null
 '
 
+yaml_long_indent = '
+a: 1
+b: [1, 2, 3]
+c: true
+d:
+    e: !expr 1+1
+    f: null
+'
+
+
+yaml_tabs = '
+a: 1
+b: [1, 2, 3]
+c: true
+d:
+\te: !expr 1+1
+\tf: null
+'
+
 if (loadable('yaml')) assert('yaml_load() works with the yaml package', {
   (yaml_load(yaml) %==% list(a = 1L, b = 1:3, c = TRUE, d = list(e = 2, f = NULL)))
   (yaml_load(yaml, envir = FALSE)[[c('d', 'e')]] %==% expression(1 + 1))
@@ -29,4 +48,16 @@ assert('yaml_load() works without the yaml package', {
     yaml_load('a: !expr head(foo, 4)', use_yaml = FALSE)
   }
   (f() %==% list(a = 1:4))
+})
+
+
+assert('yaml_load() works with variable indent', {
+  (yaml_load(yaml_long_indent, use_yaml = FALSE) %==% list(a = 1L, b = 1:3, c = TRUE, d = list(e = 2, f = NULL)))
+  (yaml_load(yaml_long_indent, envir = FALSE, use_yaml = FALSE)[[c('d', 'e')]] %==% expression(1 + 1))
+})
+
+
+assert('yaml_load() works with tabs indent', {
+  (yaml_load(yaml_tabs, use_yaml = FALSE) %==% list(a = 1L, b = 1:3, c = TRUE, d = list(e = 2, f = NULL)))
+  (yaml_load(yaml_tabs, envir = FALSE, use_yaml = FALSE)[[c('d', 'e')]] %==% expression(1 + 1))
 })

--- a/tests/test-cran/test-yaml.R
+++ b/tests/test-cran/test-yaml.R
@@ -28,6 +28,16 @@ d:
 \tf: null
 '
 
+# see https://github.com/yihui/xfun/issues/94
+yaml_mre = '
+output:
+    latex:
+        latex_engine: pdflatex
+        options:
+            toc: true
+'
+
+
 if (loadable('yaml')) assert('yaml_load() works with the yaml package', {
   (yaml_load(yaml) %==% list(a = 1L, b = 1:3, c = TRUE, d = list(e = 2, f = NULL)))
   (yaml_load(yaml, envir = FALSE)[[c('d', 'e')]] %==% expression(1 + 1))
@@ -60,4 +70,18 @@ assert('yaml_load() works with variable indent', {
 assert('yaml_load() works with tabs indent', {
   (yaml_load(yaml_tabs, use_yaml = FALSE) %==% list(a = 1L, b = 1:3, c = TRUE, d = list(e = 2, f = NULL)))
   (yaml_load(yaml_tabs, envir = FALSE, use_yaml = FALSE)[[c('d', 'e')]] %==% expression(1 + 1))
+})
+
+
+assert('yaml_load() works with a complex output', {
+  expected = list(
+    output = list(
+      latex = list(
+        latex_engine = "pdflatex", options = list(toc = TRUE)
+      )
+    )
+  )
+
+  (yaml_load(yaml_mre) %==% expected)
+  (yaml_load(yaml_mre, use_yaml = FALSE) %==% expected)
 })


### PR DESCRIPTION
Fixes #94 by implementing suggested changes from there.

Includes two tests, one with an indent of 4 spaces, and another with an indent with tabs.

Can't guarantee that it will work on every occasion.

Mixing tabs and spaces _should_ cause an error (untested).