### PR TITLE
cache_rds integration with qs

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -361,7 +361,7 @@ cache_rds = function(
 ) {
   if (loadable('knitr')) {
     if (missing(file) && !is.null(lab <- knitr::opts_current$get('label')))
-      file = paste0(lab, '.rds')
+      file = paste0(lab, if (use.qs) '.qs' else '.rds')
     if (missing(dir) && !is.null(d <- knitr::opts_current$get('cache.path')))
       dir = d
   }

--- a/man/cache_rds.Rd
+++ b/man/cache_rds.Rd
@@ -12,6 +12,7 @@ cache_rds(
   dir = "cache/",
   hash = NULL,
   clean = getOption("xfun.cache_rds.clean", TRUE),
+  use.qs = FALSE,
   ...
 )
 }
@@ -40,6 +41,9 @@ filename (see Details). It can also take a special character value
 
 \item{clean}{Whether to clean up the old cache files automatically when
 \code{expr} has changed.}
+
+\item{use.qs}{Whether to use \code{qsave} and \code{qread} from the \code{qs} package
+instead of \code{readRDS} and \code{saveRDS}}
 
 \item{...}{Other arguments to be passed to \code{\link[=saveRDS]{saveRDS()}}.}
 }
@@ -134,5 +138,8 @@ unlink(paste0(f, "_*.rds"))
 \seealso{
 \code{\link[=cache_exec]{cache_exec()}}, which is more flexible (e.g., it supports in-memory
 caching and different read/write methods for cache files).
+}
+\seealso{
+\code{qs}, which is required for \code{use.qs = TRUE}
 }
 \keyword{internal}

--- a/man/cache_rds.Rd
+++ b/man/cache_rds.Rd
@@ -138,8 +138,7 @@ unlink(paste0(f, "_*.rds"))
 \seealso{
 \code{\link[=cache_exec]{cache_exec()}}, which is more flexible (e.g., it supports in-memory
 caching and different read/write methods for cache files).
-}
-\seealso{
+
 \code{qs}, which is required for \code{use.qs = TRUE}
 }
 \keyword{internal}


### PR DESCRIPTION
I wanted to integrate the `cache_rds` function with `qs::qsave` and `qs::qread`. I know `cache_exec` already does this in some ways, but its usage has been clunky (a lot of cache invalidating that I can't seem to debug) and it is not as integrated with Rmarkdown. I much prefer the `cache_rds` interface which seems more transparent to me (and I'm frankly a lot more used to).