### PR TITLE
Match favicon.ico request by basename in resolve_path()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: xfun
 Type: Package
 Title: Supporting Functions for Packages Maintained by 'Yihui Xie'
-Version: 0.58.5
+Version: 0.58.6
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre", "cph"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666", URL = "https://yihui.org")),
   person("Wush", "Wu", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - `protect_math()` now correctly handles nested LaTeX environments (e.g., `\begin{cases}` inside `\begin{equation}`). Previously, inner environments were individually wrapped in backticks, which broke MathJax rendering (thanks, @N0rbert, #57).
 
+- Match favicon.ico request by basename in `resolve_path()` (thanks, @remlapmot, #120).
+
 - Removed the outdated note about Chrome's 2MB file size limit from the `embed_file()` documentation, since modern browsers (Chrome, Firefox, Safari) all support data URIs well over 100MB now (thanks, @grst, #23).
 
 - Fixed a regex bug in the internal `yaml_bool()` function where the pattern `'^true|false|na$'` was incorrectly parsed as `(^true)|(false)|(na$)`, causing values like `'extrafalse'` or `'trueblue'` to be treated as booleans in `taml_load()`.

--- a/R/httpd.R
+++ b/R/httpd.R
@@ -44,7 +44,9 @@ resolve_path = function(path) {
     return(list(action = 'payload', body = body, mime = 'text/html', status = 200L))
   }
   if (!file_exists(path)) {
-    if (path == 'favicon.ico') return(list(
+    # callers may pass the request path with a leading './' (e.g. servr's
+    # serve_dir()), so match on the basename instead of the exact string
+    if (basename(path) == 'favicon.ico') return(list(
       action = 'file', path = file.path(R.home('doc'), 'html', 'favicon.ico'),
       mime = 'image/x-icon'
     ))


### PR DESCRIPTION
This is related to https://github.com/rstudio/pagedown/pull/347

`resolve_path()` served R's fallback favicon only on an exact match of 'favicon.ico', but callers such as servr's `serve_dir()` rewrite the request path with a leading './' before calling `resolve_path()`, so 'favicon.ico' arrives as './favicon.ico' and the fallback never fired.

Matching `basename(path)` restores the fallback for these callers while still returning 404 for genuinely missing files. This is the regression behind the recurring `pagedown::chrome_print()` "Failed to generate output. Reason: Failed to open http://127.0.0.1:<port>/favicon.ico (HTTP status code: 404)" errors.