### PR TITLE
is_abs_path(): test paths syntactically instead of via normalizePath()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN xfun VERSION 0.61
 
+- `is_abs_path()` (and hence `is_rel_path()`) now tests paths purely syntactically instead of normalizing them on the filesystem. On Windows, `normalizePath()` could drop a trailing slash or fail to recognize certain directories (e.g., `*__files`), which made a relative path like `test/mydir/` be misclassified as absolute (thanks, @pitakakariki, #127).
+
 
 # CHANGES IN xfun VERSION 0.60
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 # CHANGES IN xfun VERSION 0.61
 
-- `is_abs_path()` (and hence `is_rel_path()`) now tests paths purely syntactically instead of normalizing them on the filesystem. On Windows, `normalizePath()` could drop a trailing slash or fail to recognize certain directories (e.g., `*__files`), which made a relative path like `test/mydir/` be misclassified as absolute (thanks, @pitakakariki, #127).
-
+- `is_abs_path()` (and hence `is_rel_path()`) now tests paths purely syntactically instead of normalizing them on the filesystem. On Windows, `normalizePath()` could drop a trailing slash, which made a relative path like `test/mydir/` be misclassified as absolute (thanks, @pitakakariki, #127).
 
 # CHANGES IN xfun VERSION 0.60
 

--- a/R/paths.R
+++ b/R/paths.R
@@ -277,8 +277,6 @@ get_subpath = function(p, n1, n2) {
 #' xfun::is_abs_path(c('C:/foo', 'foo.txt', '/Users/john/', tempdir()))
 #' xfun::is_rel_path(c('C:/foo', 'foo.txt', '/Users/john/', tempdir()))
 is_abs_path = function(x) {
-  # test is purely syntactic: don't touch the filesystem (normalizePath() can
-  # drop trailing slashes and fail to recognize certain dirs on Windows, #127)
   grepl(if (is_unix()) '^[/~]' else '^([a-zA-Z]:|[/\\\\~])', x)
 }
 

--- a/R/paths.R
+++ b/R/paths.R
@@ -267,9 +267,9 @@ get_subpath = function(p, n1, n2) {
 #' Test if paths are relative or absolute
 #'
 #' On Unix, check if the paths start with \file{/} or \file{~} (if they do, they
-#' are absolute paths). On Windows, check if a path remains the same (via
-#' [xfun::same_path()]) if it is prepended with \file{./} (if it does, it is a
-#' relative path).
+#' are absolute paths). On Windows, check if the paths start with a drive letter
+#' (e.g., \file{C:}), a (back)slash (e.g., \file{/foo}), or a UNC prefix (e.g.,
+#' \file{\\\\host\\share}).
 #' @param x A vector of paths.
 #' @return A logical vector.
 #' @export
@@ -277,7 +277,9 @@ get_subpath = function(p, n1, n2) {
 #' xfun::is_abs_path(c('C:/foo', 'foo.txt', '/Users/john/', tempdir()))
 #' xfun::is_rel_path(c('C:/foo', 'foo.txt', '/Users/john/', tempdir()))
 is_abs_path = function(x) {
-  if (is_unix()) grepl('^[/~]', x) else !same_path(x, file.path('.', x))
+  # test is purely syntactic: don't touch the filesystem (normalizePath() can
+  # drop trailing slashes and fail to recognize certain dirs on Windows, #127)
+  grepl(if (is_unix()) '^[/~]' else '^([a-zA-Z]:|[/\\\\])', x)
 }
 
 #' @rdname is_abs_path

--- a/R/paths.R
+++ b/R/paths.R
@@ -268,8 +268,8 @@ get_subpath = function(p, n1, n2) {
 #'
 #' On Unix, check if the paths start with \file{/} or \file{~} (if they do, they
 #' are absolute paths). On Windows, check if the paths start with a drive letter
-#' (e.g., \file{C:}), a (back)slash (e.g., \file{/foo}), or a UNC prefix (e.g.,
-#' \file{\\\\host\\share}).
+#' (e.g., \file{C:}), a (back)slash (e.g., \file{/foo}), a UNC prefix (e.g.,
+#' \file{\\\\host\\share}), or \file{~}.
 #' @param x A vector of paths.
 #' @return A logical vector.
 #' @export
@@ -279,7 +279,7 @@ get_subpath = function(p, n1, n2) {
 is_abs_path = function(x) {
   # test is purely syntactic: don't touch the filesystem (normalizePath() can
   # drop trailing slashes and fail to recognize certain dirs on Windows, #127)
-  grepl(if (is_unix()) '^[/~]' else '^([a-zA-Z]:|[/\\\\])', x)
+  grepl(if (is_unix()) '^[/~]' else '^([a-zA-Z]:|[/\\\\~])', x)
 }
 
 #' @rdname is_abs_path

--- a/man/is_abs_path.Rd
+++ b/man/is_abs_path.Rd
@@ -17,9 +17,9 @@ A logical vector.
 }
 \description{
 On Unix, check if the paths start with \file{/} or \file{~} (if they do, they
-are absolute paths). On Windows, check if a path remains the same (via
-\code{\link[=same_path]{same_path()}}) if it is prepended with \file{./} (if it does, it is a
-relative path).
+are absolute paths). On Windows, check if the paths start with a drive letter
+(e.g., \file{C:}), a (back)slash (e.g., \file{/foo}), or a UNC prefix (e.g.,
+\file{\\\\host\\share}).
 }
 \examples{
 xfun::is_abs_path(c("C:/foo", "foo.txt", "/Users/john/", tempdir()))

--- a/man/is_abs_path.Rd
+++ b/man/is_abs_path.Rd
@@ -18,8 +18,8 @@ A logical vector.
 \description{
 On Unix, check if the paths start with \file{/} or \file{~} (if they do, they
 are absolute paths). On Windows, check if the paths start with a drive letter
-(e.g., \file{C:}), a (back)slash (e.g., \file{/foo}), or a UNC prefix (e.g.,
-\file{\\\\host\\share}).
+(e.g., \file{C:}), a (back)slash (e.g., \file{/foo}), a UNC prefix (e.g.,
+\file{\\\\host\\share}), or \file{~}.
 }
 \examples{
 xfun::is_abs_path(c("C:/foo", "foo.txt", "/Users/john/", tempdir()))

--- a/tests/test-cran/test-paths.R
+++ b/tests/test-cran/test-paths.R
@@ -61,9 +61,11 @@ assert('is_abs_path() recognizes absolute paths on Windows and *nix', {
   (!is_abs_path('test/mydir/'))
   (!is_abs_path('foo__files/'))
   (is_rel_path('foo__files/'))
+  # '~' is absolute on all platforms (path.expand() maps it to the home dir)
+  (is_abs_path('~/foo'))
   (is_abs_path(if (.Platform$OS.type == 'windows') {
     c('D:\\abc', '\\\\netdrive\\somewhere', 'C:/foo', '/foo', '\\foo')
-  } else c('/abc/def', '~/foo')))
+  } else '/abc/def'))
 })
 
 assert('del_empty_dir() correctly deletes empty dirs', {

--- a/tests/test-cran/test-paths.R
+++ b/tests/test-cran/test-paths.R
@@ -55,9 +55,15 @@ assert('url_filename() returns the file names in URLs', {
 
 assert('is_abs_path() recognizes absolute paths on Windows and *nix', {
   (!is_abs_path('abc/def'))
+  # a trailing slash must not change the result (#127); a purely syntactic test
+  # also works for non-existent or hard-to-normalize dirs (e.g., '*__files')
+  (!is_abs_path('abc/def/'))
+  (!is_abs_path('test/mydir/'))
+  (!is_abs_path('foo__files/'))
+  (is_rel_path('foo__files/'))
   (is_abs_path(if (.Platform$OS.type == 'windows') {
-    c('D:\\abc', '\\\\netdrive\\somewhere')
-  } else '/abc/def'))
+    c('D:\\abc', '\\\\netdrive\\somewhere', 'C:/foo', '/foo', '\\foo')
+  } else c('/abc/def', '~/foo')))
 })
 
 assert('del_empty_dir() correctly deletes empty dirs', {

--- a/tests/test-cran/test-paths.R
+++ b/tests/test-cran/test-paths.R
@@ -54,16 +54,11 @@ assert('url_filename() returns the file names in URLs', {
 })
 
 assert('is_abs_path() recognizes absolute paths on Windows and *nix', {
-  (!is_abs_path('abc/def'))
-  # a trailing slash must not change the result (#127); a purely syntactic test
-  # also works for non-existent or hard-to-normalize dirs (e.g., '*__files')
-  (!is_abs_path('abc/def/'))
-  (!is_abs_path('test/mydir/'))
-  (!is_abs_path('foo__files/'))
-  (is_rel_path('foo__files/'))
+  # a trailing slash must not change the result (#127)
+  (is_rel_path(c('abc/def', 'abc/def/', 'test/mydir/', 'foo__files/')))
   # '~' is absolute on all platforms (path.expand() maps it to the home dir)
   (is_abs_path('~/foo'))
-  (is_abs_path(if (.Platform$OS.type == 'windows') {
+  (is_abs_path(if (is_windows()) {
     c('D:\\abc', '\\\\netdrive\\somewhere', 'C:/foo', '/foo', '\\foo')
   } else '/abc/def'))
 })


### PR DESCRIPTION
Fixes #127.

## Root cause

`is_abs_path()` (and hence `is_rel_path()`) on Windows compared the path to `file.path('.', x)` after normalization via `same_path()` → `normalize_path()` → `normalizePath()`. But `normalizePath()` on Windows:

- drops a trailing slash, and
- fails to recognize certain directories such as `*__files` even when `dir.exists()` returns `TRUE` (`normalizePath('*__files', mustWork = TRUE)` throws).

As a result a relative path like `test/mydir/` was misclassified as **absolute**, which downstream (e.g. `litedown::fuse("test/001.Rmd")`) left behind a stray working directory at `test/test/001__files`.

## Fix

Whether a path is absolute is a purely syntactic property, so test it with a regex and never touch the filesystem:

```r
is_abs_path = function(x) {
  grepl(if (is_unix()) '^[/~]' else '^([a-zA-Z]:|[/\\\\])', x)
}
```

On Windows a path is absolute if it starts with a drive letter (`C:`), a (back)slash, or a UNC prefix (`\\host\share`). This fixes both the trailing-slash and the `*__files` cases and can no longer throw.

Supersedes #128, which patched only the trailing-slash symptom and routed through the same fragile `normalizePath()` comparison. Thanks @pitakakariki for the diagnosis and the original PR.

## Tests

Added cases to `tests/test-cran/test-paths.R` for trailing slashes, `*__files`-style dirs, and additional Windows absolute forms (`C:/foo`, `/foo`, `\foo`). Full test suite passes (the only failure is an unrelated network error hitting an internal CRAN mirror in `test-ci`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)