### PR TITLE
browser_print(): drop the PDF header and footer by default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: xfun
 Type: Package
 Title: Supporting Functions for Packages Maintained by 'Yihui Xie'
-Version: 0.60.2
+Version: 0.60.3
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre", "cph"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666", URL = "https://yihui.org")),
   person("Wush", "Wu", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - `is_abs_path()` (and hence `is_rel_path()`) now tests paths purely syntactically instead of normalizing them on the filesystem. On Windows, `normalizePath()` could drop a trailing slash, which made a relative path like `test/mydir/` be misclassified as absolute (thanks, @pitakakariki, #127).
 
+- `browser_print()` now passes `--no-pdf-header-footer` by default when printing to PDF (with the default `args`), so the printed PDF no longer carries the date, page title, and file path in its header and footer.
+
 # CHANGES IN xfun VERSION 0.60
 
 - `read_utf8()` gained a new argument `binary` (defaulting to `FALSE`). On Windows, `readLines()` on a text-mode connection treats a `Ctrl+Z` byte (`\x1a`) as end-of-file and silently truncates files that contain this byte (e.g., self-contained HTML files that embed the PNG signature `\x89PNG\r\n\x1a\n` in JavaScript). Setting `binary = TRUE` reads the file via a binary-mode connection, which reads the whole file regardless of `Ctrl+Z` bytes (thanks, @dmurdoch, rstudio/bookdown#1523).

--- a/R/browser.R
+++ b/R/browser.R
@@ -40,9 +40,8 @@ browser_print = function(
     ), 'default')
   }
   args = c(args, sprintf(
-    '--%s="%s"', if (to_pdf) 'print-to-pdf' else 'screenshot',
-    normalize_path(output)), shQuote(input)
-  )
+    '--%s="%s"', if (to_pdf) 'print-to-pdf' else 'screenshot', normalize_path(output)
+  ), shQuote(input))
   if (system2(browser, args, stderr = FALSE) != 0) stop('Failed to print to ', output)
   output
 }

--- a/R/browser.R
+++ b/R/browser.R
@@ -34,6 +34,9 @@ browser_print = function(
   if ('default' %in% args) {
     args = setdiff(c(
       args, browser_args(),
+      # Chromium otherwise stamps the date, page title, and file path into the
+      # PDF's header and footer, which is just noise for programmatic printing.
+      if (to_pdf) '--no-pdf-header-footer',
       sprintf('--%s="%s"', if (to_pdf) 'print-to-pdf' else 'screenshot', normalize_path(output)),
       shQuote(input)
     ), 'default')

--- a/R/browser.R
+++ b/R/browser.R
@@ -9,8 +9,8 @@
 #' @param args Command-line arguments to be passed to the headless browser. The
 #'   default arguments can be found in `xfun:::browser_args()`. You may pass
 #'   additional arguments on top of these via, e.g., `c('default',
-#'   '--no-pdf-header-footer')`, or completely override the default arguments by
-#'   providing a vector of other arguments.
+#'   '--force-device-scale-factor=2')`, or completely override the default
+#'   arguments by providing a vector of other arguments.
 #' @param window_size The browser window size when taking a PNG/JPEG screenshot.
 #'   Ignored when printing to PDF.
 #' @param browser Path to the web browser. By default, the browser is found via
@@ -36,11 +36,13 @@ browser_print = function(
       args, browser_args(),
       # Chromium otherwise stamps the date, page title, and file path into the
       # PDF's header and footer, which is just noise for programmatic printing.
-      if (to_pdf) '--no-pdf-header-footer',
-      sprintf('--%s="%s"', if (to_pdf) 'print-to-pdf' else 'screenshot', normalize_path(output)),
-      shQuote(input)
+      if (to_pdf) '--no-pdf-header-footer'
     ), 'default')
   }
+  args = c(args, sprintf(
+    '--%s="%s"', if (to_pdf) 'print-to-pdf' else 'screenshot',
+    normalize_path(output)), shQuote(input)
+  )
   if (system2(browser, args, stderr = FALSE) != 0) stop('Failed to print to ', output)
   output
 }

--- a/man/browser_print.Rd
+++ b/man/browser_print.Rd
@@ -21,8 +21,8 @@ filename will be inferred from \code{url} via \code{\link[=url_filename]{url_fil
 
 \item{args}{Command-line arguments to be passed to the headless browser. The
 default arguments can be found in \code{xfun:::browser_args()}. You may pass
-additional arguments on top of these via, e.g., \code{c('default', '--no-pdf-header-footer')}, or completely override the default arguments by
-providing a vector of other arguments.}
+additional arguments on top of these via, e.g., \code{c('default', '--force-device-scale-factor=2')}, or completely override the default
+arguments by providing a vector of other arguments.}
 
 \item{window_size}{The browser window size when taking a PNG/JPEG screenshot.
 Ignored when printing to PDF.}


### PR DESCRIPTION
When printing to PDF, Chromium stamps the date, page title, and file path into the header and footer of every page. For programmatic printing this is just noise (and the temp-file path is meaningless to the reader).

`browser_print()` now adds `--no-pdf-header-footer` by default when the output is a PDF — but only inside the `"default" %in% args` branch, so it composes with the existing headless/print flags and a caller who overrides `args` entirely still gets full control.

Placed in the `to_pdf` branch of `browser_print()` rather than in `browser_args()`, since `browser_args()` is shared with `browser_dom()` (dump-DOM) where the flag is meaningless.

Surfaced from yihui/lt#7, where uncropped PDF export showed the temp-file path in the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)